### PR TITLE
make module override in subcommands a flag

### DIFF
--- a/src/k16/kl/commands/containers.clj
+++ b/src/k16/kl/commands/containers.clj
@@ -18,7 +18,7 @@
    :description "Select containers to run"
 
    :opts [{:option "module"
-           :short 0
+           :short "m"
            :type :string}]
 
    :runs (fn [props]
@@ -43,7 +43,7 @@
    :description "Select containers to run"
 
    :opts [{:option "module"
-           :short 0
+           :short "m"
            :type :string}]
 
    :runs (fn [props]
@@ -90,7 +90,7 @@
    :description "Stop all running containers "
 
    :opts [{:option "module"
-           :short 0
+           :short "m"
            :type :string}]
 
    :runs (fn [props]

--- a/src/k16/kl/commands/endpoints.clj
+++ b/src/k16/kl/commands/endpoints.clj
@@ -38,10 +38,11 @@
                   :description "List all endpoints"
 
                   :opts [{:option "module"
-                          :short 0
+                          :short "m"
                           :type :string}
 
                          {:option "service"
+                          :short 0
                           :type :string}]
 
                   :runs list-endpoints}]})

--- a/src/k16/kl/commands/modules.clj
+++ b/src/k16/kl/commands/modules.clj
@@ -33,11 +33,12 @@
                   :description "Pull down changes to a module"
 
                   :opts [{:option "module"
-                          :short 0
+                          :short "m"
                           :type :string}
 
                          {:option "update"
                           :default false
+                          :short 0
                           :type :with-flag}]
 
                   :runs pull!}
@@ -46,11 +47,12 @@
                   :description "Resolve the latest sha's of a module. This is the same as `pull --update`"
 
                   :opts [{:option "module"
-                          :short 0
+                          :short "m"
                           :type :string}
 
                          {:option "force"
                           :default false
+                          :short 0
                           :type :with-flag}]
 
                   :runs (fn [props]

--- a/src/k16/kl/commands/routes.clj
+++ b/src/k16/kl/commands/routes.clj
@@ -91,7 +91,7 @@
                   :description "List all routes"
 
                   :opts [{:option "module"
-                          :short 0
+                          :short "m"
                           :type :string}
 
                          {:option "output"
@@ -105,7 +105,7 @@
                   :description "Apply any route changes"
 
                   :opts [{:option "module"
-                          :short 0
+                          :short "m"
                           :type :string}]
 
                   :runs apply-routes!}]})

--- a/src/k16/kl/commands/services.clj
+++ b/src/k16/kl/commands/services.clj
@@ -77,7 +77,7 @@
                   :description "List all services"
 
                   :opts [{:option "module"
-                          :short 0
+                          :short "m"
                           :type :string}]
 
                   :runs list-services}
@@ -86,13 +86,13 @@
                   :description "Set the default endpoint for a service"
 
                   :opts [{:option "module"
-                          :short 0
+                          :short "m"
                           :type :string}
                          {:option "service"
-                          :short 1
+                          :short 0
                           :type :string}
                          {:option "endpoint"
-                          :short 2
+                          :short 1
                           :type :string}]
 
                   :runs set-default-service-endpoint!}]})


### PR DESCRIPTION
The module option was a positional argument for most commands, but that does not make sense to me because: 
- You can set a default (the common use-case) 
- If you omit the module, and do not have a default module set, you will be prompted to select a module to operate on
- The subcommands read something like this: 
     `kl services set-endpoint <module-name> <service-name> <"host" | "container">` 
      This read easier in my opinion: 
      `kl services set-endpoint <service-name> <"host" | "container>` with the option to specify `-m` or `--module` to override